### PR TITLE
Update to use k3s-root v0.6.0-rc3 xtables autodetection and clone from rancher/flannel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,29 @@ FROM ${UBI_IMAGE} as ubi
 
 FROM ${GO_IMAGE} as builder
 ARG TAG="" 
+ARG K3S_ROOT_VERSION=v0.6.0-rc3
 RUN apt update     && \ 
     apt upgrade -y && \ 
     apt install -y ca-certificates git
 
-RUN git clone --depth=1 https://github.com/coreos/flannel.git /go/src/github.com/coreos/flannel
-RUN cd /go/src/github.com/coreos/flannel && \
+RUN mkdir -p /tmp/xtables && \
+    curl -L https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-amd64.tar -o /tmp/xtables/k3s-root-xtables.tar && \
+    tar -C /tmp/xtables -xvf /tmp/xtables/k3s-root-xtables.tar
+
+RUN git clone --depth=1 https://github.com/rancher/flannel.git /go/src/github.com/rancher/flannel
+RUN cd /go/src/github.com/rancher/flannel && \
     git fetch --all --tags --prune       && \
     git checkout tags/${TAG} -b ${TAG}   && \
     make dist/flanneld
 
 FROM ubi
-RUN microdnf update -y                                           && \
-    microdnf install -y yum                                      && \
-    yum install -y ca-certificates strongswan iptables net-tools && \
-    rm -rf /var/cache/yum                                        && \
+RUN microdnf update -y                                  && \
+    microdnf install -y yum                             && \
+    yum install -y ca-certificates strongswan net-tools && \
+    rm -rf /var/cache/yum                               && \
     mkdir -p /opt/bin
 
-COPY --from=builder /go/src/github.com/coreos/flannel/dist/flanneld /opt/bin
+COPY --from=builder /tmp/xtables/bin/* /usr/sbin/
+
+COPY --from=builder /go/src/github.com/rancher/flannel/dist/flanneld /opt/bin
 


### PR DESCRIPTION
This changes kube-proxy to use the iptables provided by k3s-root (1.8.3) rather than using the ubi7 provided iptables. This allows for switching between nft and legacy on the fly.

This also changes to cloning from `rancher/flannel` instead of `coreos/flannel`

https://github.com/rancher/rke2/issues/16

Signed-off-by: Chris Kim <oats87g@gmail.com>