### PR TITLE
statically linked flanneld

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,25 +7,22 @@ platform:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - sleep 20
-  - TAG=${DRONE_TAG} make
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG}
 
-- name: push
-  image: rancher/hardened-build-base:v1.14.2-amd64
+- name: publish
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - TAG=${DRONE_TAG} make image-push
+  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
   environment:
     DOCKER_USERNAME:
       from_secret: docker_username
@@ -36,26 +33,12 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
-  - TAG=${DRONE_TAG} make image-scan
-  when:
-    event:
-    - tag
-
-- name: manifest
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-  - name: dockersock
-    path: /var/run
-  commands:
-  - TAG=${DRONE_TAG} make image-manifest
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG} image-scan
 
 services:
 - name: docker
@@ -66,5 +49,5 @@ services:
     path: /var/run
 
 volumes:
-  - name: dockersock
-    temp: {}
+- name: dockersock
+  temp: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,40 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.14.2-amd64
-
+ARG GO_IMAGE=rancher/hardened-build-base:v1.15.2b5
 FROM ${UBI_IMAGE} as ubi
-
 FROM ${GO_IMAGE} as builder
-ARG TAG="" 
-ARG K3S_ROOT_VERSION=v0.6.0-rc3
-RUN apt update     && \ 
-    apt upgrade -y && \ 
-    apt install -y ca-certificates git
-
-RUN mkdir -p /tmp/xtables && \
-    curl -L https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-amd64.tar -o /tmp/xtables/k3s-root-xtables.tar && \
-    tar -C /tmp/xtables -xvf /tmp/xtables/k3s-root-xtables.tar
-
-RUN git clone --depth=1 https://github.com/rancher/flannel.git /go/src/github.com/rancher/flannel
-RUN cd /go/src/github.com/rancher/flannel && \
-    git fetch --all --tags --prune       && \
-    git checkout tags/${TAG} -b ${TAG}   && \
-    make dist/flanneld
+# setup required packages
+RUN set -x \
+ && apk --no-cache add \
+    file \
+    gcc \
+    git \
+    linux-headers \
+    make
+# setup the build
+ARG ARCH="amd64"
+ARG K3S_ROOT_VERSION="v0.6.0-rc3"
+ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
+RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
+ARG TAG="v0.13.0-rancher1"
+ARG PKG="github.com/coreos/flannel"
+ARG SRC="github.com/rancher/flannel"
+RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
+WORKDIR $GOPATH/src/${PKG}
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+# build and assert statically linked executable(s)
+ENV GO_LDFLAGS="-X ${PKG}/version.Version=${TAG}"
+RUN go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/flanneld .
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh bin/*
+RUN install -s bin/* /usr/local/bin
+RUN flanneld --version
 
 FROM ubi
 RUN microdnf update -y          && \
     microdnf install -y yum     && \
     yum install -y ca-certificates \
     strongswan net-tools which  && \
-    rm -rf /var/cache/yum       && \
-    mkdir -p /opt/bin
-
-COPY --from=builder /tmp/xtables/bin/* /usr/sbin/
-
-COPY --from=builder /go/src/github.com/rancher/flannel/dist/flanneld /opt/bin
-
+    rm -rf /var/cache/yum
+COPY --from=builder /opt/xtables/bin/ /usr/sbin/
+COPY --from=builder /usr/local/bin/ /opt/bin/


### PR DESCRIPTION
Leverage new alpine-based rancher/hardened-build-base (goboring built on
alpine) while matching the upstream version of go to compile with. Also
assert everything is statically linked and assert presence of goboring
symbols prior to install-with-strip.

Addresses rancher/rke2#335
