### PR TITLE
Update to use UBI8, newer Strongswan, and not install Yum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG UBI_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.15.8b5
 FROM ${UBI_IMAGE} as ubi
 FROM ${GO_IMAGE} as builder
@@ -31,10 +31,12 @@ RUN install -s bin/* /usr/local/bin
 RUN flanneld --version
 
 FROM ubi
-RUN microdnf update -y          && \
-    microdnf install -y yum     && \
-    yum install -y ca-certificates \
+RUN microdnf update -y && \
+    rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    microdnf clean all && \
+    microdnf install -y ca-certificates \
     strongswan net-tools which  && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/yum && \
+    microdnf remove epel-release
 COPY --from=builder /opt/xtables/bin/ /usr/sbin/
 COPY --from=builder /usr/local/bin/ /opt/bin/


### PR DESCRIPTION
Strongswan doesn't appear to be available in the UBI repositories and has some dependency issues in UBI 7 so I am proposing the switch to UBI 8 and adding the EPEL repo to install a newer Strongswan. This also removes some private keys installed from pygpgme package installed as a result of installing yum. I don't know if there are other dependency ramifications from upping Strongswan or switching to UBI 8 so this is merely a suggestion.