### PR TITLE
Update flannel to 0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ ARG ARCH="amd64"
 ARG K3S_ROOT_VERSION="v0.8.1"
 ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
 RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
-ARG TAG="v0.13.0-rancher1"
-ARG PKG="github.com/coreos/flannel"
-ARG SRC="github.com/rancher/flannel"
+ARG TAG="v0.14.0"
+ARG PKG="github.com/flannel-io/flannel"
+ARG SRC="github.com/flannel-io/flannel"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-PKG ?= github.com/coreos/flannel
-SRC ?= github.com/rancher/flannel
-TAG ?= v0.13.0-rancher1$(BUILD_META)
+PKG ?= github.com/flannel-io/flannel
+SRC ?= github.com/flannel-io/flannel
+TAG ?= v0.14.0$(BUILD_META)
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Build
 
 ```sh
-TAG=v0.11.0 make
+TAG=v0.14.0 make
 ```


### PR DESCRIPTION
- Stop using our fork of flannel and start using the upstream repo
- Upstream repo is now https://github.com/flannel-io/flannel and not coreos/flannel
- Update flannel to 0.14

Signed-off-by: Manuel Buil <mbuil@suse.com>