### PR TITLE
Bump versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ platform:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.16.12b7
   commands:
   - make DRONE_TAG=${DRONE_TAG}
   volumes:
@@ -18,7 +18,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.16.12b7
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push
@@ -35,7 +35,7 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.16.12b7
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-scan
   volumes:
@@ -61,7 +61,7 @@ node:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.16.12b7
   failure: ignore
   commands:
     - make DRONE_TAG=${DRONE_TAG}
@@ -70,7 +70,7 @@ steps:
       path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.16.12b7
   failure: ignore
   commands:
     - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.16.10b7
+ARG UBI_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:latest
+ARG GO_IMAGE=rancher/hardened-build-base:v1.16.12b7
 FROM ${UBI_IMAGE} as ubi
 FROM ${GO_IMAGE} as builder
 # setup required packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG ARCH="amd64"
 ARG K3S_ROOT_VERSION="v0.9.1"
 ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
 RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
-ARG TAG="v0.15.1"
+ARG TAG="v0.16.1"
 ARG PKG="github.com/flannel-io/flannel"
 ARG SRC="github.com/flannel-io/flannel"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM ubi
 RUN microdnf update -y          && \
     microdnf install -y yum     && \
     yum install -y ca-certificates \
-    strongswan net-tools which  && \
+    net-tools which  && \
     rm -rf /var/cache/yum
 COPY --from=builder /opt/xtables/bin/ /usr/sbin/
 COPY --from=builder /usr/local/bin/ /opt/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     make
 # setup the build
 ARG ARCH="amd64"
-ARG K3S_ROOT_VERSION="v0.9.1"
+ARG K3S_ROOT_VERSION="v0.11.0"
 ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
 RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
 ARG TAG="v0.16.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:latest
+ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.16.12b7
 FROM ${UBI_IMAGE} as ubi
 FROM ${GO_IMAGE} as builder
@@ -36,7 +36,7 @@ FROM ubi
 RUN microdnf update -y          && \
     microdnf install -y yum     && \
     yum install -y ca-certificates \
-    net-tools which  && \
+    strongswan net-tools which  && \
     rm -rf /var/cache/yum
 COPY --from=builder /opt/xtables/bin/ /usr/sbin/
 COPY --from=builder /usr/local/bin/ /opt/bin/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
 PKG ?= github.com/flannel-io/flannel
 SRC ?= github.com/flannel-io/flannel
-TAG ?= v0.15.1$(BUILD_META)
-K3S_ROOT_VERSION ?= v0.10.1
+TAG ?= v0.16.1$(BUILD_META)
+K3S_ROOT_VERSION ?= v0.11.0
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Build
 
 ```sh
-TAG=v0.15.1 make
+TAG=v0.16.1 make
 ```


### PR DESCRIPTION
With the new version [v0.16.1](https://github.com/flannel-io/flannel/releases/tag/v0.16.1) the Wireguard extension now made it into an official release, also a big thank you to @manuelbuil for making this possible!