### PR TITLE
CI will ignore push to non-master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.4b11
@@ -41,6 +47,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 volumes:
 - name: docker
@@ -68,6 +80,12 @@ steps:
   volumes:
     - name: docker
       path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/pull/**
+      - refs/tags/*
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.4b11


### PR DESCRIPTION
This contributes to rancher/rke2#4248

We want CI to exclude push events from dev or automated branches