### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifneq ($(DRONE_TAG),)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
-	$(error TAG needs to end with build metadata: $(BUILD_META))
+$(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
 .PHONY: image-build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
 # rancher/hardened-flannel
-
-## Build
-
-```sh
-TAG=v0.24.2 make
-```

--- a/updatecli/updatecli.d/updateflannel.yaml
+++ b/updatecli/updatecli.d/updateflannel.yaml
@@ -40,17 +40,6 @@ targets:
       matchpattern: '(?m)^TAG \?\= (.*)'
       replacepattern: 'TAG ?= {{ source "flannel" }}$$(BUILD_META)'
 
-  readme:
-    name: "Bump to latest flannel version in README"
-    kind: file
-    scmid: default
-    disablesourceinput: true
-    spec:
-      file: README.md
-      matchpattern: '(?m)^TAG=(.*)'
-      replacepattern: 'TAG={{ source "flannel" }} make'
-
-
 scms:
   default:
     kind: github


### PR DESCRIPTION
The tab in the Makefile is wrong because in that case it believes it is a recipe, so we get the error:
```
*** recipe commences before first target.  Stop.
```
As the Makefile is quite simple, and has been wrong for a long time, I think it is fine if we just remove the instruction. Then we tell updatecli to not update it anymore