### PR TITLE
Add drone again to publish (temporarily)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,113 @@
+---
+kind: pipeline
+type: docker
+name: linux-amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  pull: always
+  image: rancher/hardened-build-base:v1.20.7b3
+  commands:
+  - make DRONE_TAG=${DRONE_TAG}
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+
+- name: publish
+  image: rancher/hardened-build-base:v1.20.7b3
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - make DRONE_TAG=${DRONE_TAG} image-push
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+type: docker
+name: linux-arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  pull: always
+  image: rancher/hardened-build-base:v1.20.7b3
+  commands:
+  - make DRONE_TAG=${DRONE_TAG}
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+
+- name: publish
+  image: rancher/hardened-build-base:v1.20.7b3
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - make DRONE_TAG=${DRONE_TAG} image-push
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+type: docker
+name: manifest
+platform:
+  os: linux
+  arch: amd64
+steps:
+- name: push
+  image: plugins/manifest:1.2.3
+  settings:
+    password:
+      from_secret: docker_password
+    username:
+      from_secret: docker_username
+    spec: manifest.tmpl
+    ignore_missing: true
+  when:
+    event:
+    - tag
+depends_on:
+- linux-amd64
+- linux-arm64
+...
+

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,0 +1,12 @@
+image: rancher/hardened-flannel:{{build.tag}}
+manifests:
+  -
+    image: rancher/hardened-flannel:{{build.tag}}-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: rancher/hardened-flannel:{{build.tag}}-arm64
+    platform:
+      architecture: arm64
+      os: linux


### PR DESCRIPTION
Unfortunately, EIO will require longer than expected to set-up the dockerhub credentials. Therefore, we should use drone in order to publish images for the April release