### PR TITLE
Use latest as version filter

### DIFF
--- a/updatecli/updatecli.d/updateflannel.yaml
+++ b/updatecli/updatecli.d/updateflannel.yaml
@@ -14,9 +14,7 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: semver
-       # pattern accepts any semver constraint
-       pattern: "*"
+       kind: latest
 
 targets:
   dockerfile:


### PR DESCRIPTION
In previous weeks, updatecli was unable to detect the new version of Flannel. In other repos something similar happened and that's why we moved to `latest`. This PR does the same for image-build-flannel