### PR TITLE
publish-image action

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -20,7 +20,10 @@ jobs:
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
 
     - name: Build and push image
       uses: rancher/ecm-distro-tools/actions/publish-image@master
@@ -30,4 +33,8 @@ jobs:
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-        push-to-prime: false
+
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -15,14 +15,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Set the TAG value
-      id: get-TAG
-      run: |
-        echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
-        
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    
     - name: "Read secrets"
       uses: rancher-eio/read-vault-secrets@main
       with:
@@ -30,22 +22,12 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to Container Registry
-      uses: docker/login-action@v3
+    - name: Build and push image
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
-
-    - name: Build container image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        push: true
-        tags: rancher/hardened-flannel:${{ github.event.release.tag_name }}
-        file: Dockerfile
-        platforms: linux/amd64, linux/arm64
-        build-args: |
-          TAG=${{ env.TAG }}
+        image: hardened-flannel
+        tag: ${{ github.event.release.tag_name }}
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        push-to-prime: false

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ image-build:
 push-image:
 	docker buildx build \
 		$(BUILD_OPTS) \
+		$(IID_FILE_FLAG) \
 		--sbom=true \
 		--attest type=provenance,mode=max \
 		--push \

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 SEVERITIES = HIGH,CRITICAL
 
 UNAME_M = $(shell uname -m)
-ARCH=
-ifeq ($(UNAME_M), x86_64)
-	ARCH=amd64
-else ifeq ($(UNAME_M), aarch64)
-	ARCH=arm64
-else 
-	ARCH=$(UNAME_M)
+ifndef TARGET_PLATFORMS
+	ifeq ($(UNAME_M), x86_64)
+		TARGET_PLATFORMS:=linux/amd64
+	else ifeq ($(UNAME_M), aarch64)
+		TARGET_PLATFORMS:=linux/arm64
+	else 
+		TARGET_PLATFORMS:=linux/$(UNAME_M)
+	endif
 endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
-ORG ?= rancher
 PKG ?= github.com/flannel-io/flannel
 SRC ?= github.com/flannel-io/flannel
 TAG ?= ${GITHUB_ACTION_TAG}
@@ -25,43 +25,45 @@ ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG ${TAG} needs to end with build metadata: $(BUILD_META))
 endif
 
+REPO ?= rancher
+IMAGE = $(REPO)/hardened-flannel:$(TAG)
+BUILD_OPTS = \
+	--platform=$(TARGET_PLATFORMS) \
+	--build-arg PKG=$(PKG) \
+	--build-arg SRC=$(SRC) \
+	--build-arg TAG=$(TAG:$(BUILD_META)=) \
+	--build-arg K3S_ROOT_VERSION=$(K3S_ROOT_VERSION) \
+	--tag "$(IMAGE)"
+
 .PHONY: image-build
 image-build:
 	docker build \
+		$(BUILD_OPTS) \
 		--pull \
-		--build-arg ARCH=$(ARCH) \
-		--build-arg PKG=$(PKG) \
-		--build-arg SRC=$(SRC) \
-		--build-arg TAG=$(TAG:$(BUILD_META)=) \
-		--tag $(ORG)/hardened-flannel:$(TAG) \
-		--tag $(ORG)/hardened-flannel:$(TAG)-$(ARCH) \
-		--build-arg K3S_ROOT_VERSION=$(K3S_ROOT_VERSION) \
 		.
 
-.PHONY: image-push
-image-push:
-	docker push $(ORG)/hardened-flannel:$(TAG)-$(ARCH)
-
-.PHONY: image-manifest
-image-manifest:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-flannel:$(TAG) \
-		$(ORG)/hardened-flannel:$(TAG)-$(ARCH)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-flannel:$(TAG)
+.PHONY: push-image
+push-image:
+	docker buildx build \
+		$(BUILD_OPTS) \
+		--sbom=true \
+		--attest type=provenance,mode=max \
+		--push \
+		.
 
 .PHONY: image-scan
 image-scan:
-	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-flannel:$(TAG)
+	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(IMAGE)
 
 .PHONY: log
 log:
-	@echo "ARCH=$(ARCH)"
 	@echo "TAG=$(TAG:$(BUILD_META)=)"
-	@echo "ORG=$(ORG)"
+	@echo "REPO=$(REPO)"
+	@echo "IMAGE=$(IMAGE)"
 	@echo "PKG=$(PKG)"
 	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"
 	@echo "K3S_ROOT_VERSION=$(K3S_ROOT_VERSION)"
 	@echo "UNAME_M=$(UNAME_M)"
+	@echo "TARGET_PLATFORMS=$(TARGET_PLATFORMS)"
 


### PR DESCRIPTION
- use rancher/ecm-distro-tools/actions/publish-image to build and push images
- adds make target push-image
- adds sbom to docker build arguments
- signs images that are pushed to the prime registry