### PR TITLE
revert to bci-busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
+# bci-busybox is needed to run iptables-detect.sh when the container starts
+ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.25.11b1
 ARG XX_IMAGE=rancher/mirrored-tonistiigi-xx:1.6.1
 


### PR DESCRIPTION
bci-busybox is needed to run iptables-detect.sh when the container starts