### PR TITLE
Override golang.org/x/net@v0.56.0 and golang.org/x/text@v0.39.0 to fix CVEs

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,3 +1,7 @@
-# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
-# Drop once upstream requires golang.org/x/net >= v0.55.0.
--replace golang.org/x/net=golang.org/x/net@v0.55.0
+# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode), CVE-2026-46600 (x/net/dns/dnsmessage panic parsing invalid SVCB or HTTPS RR).
+# Drop once upstream requires golang.org/x/net >= v0.56.0.
+-replace golang.org/x/net=golang.org/x/net@v0.56.0
+
+# golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
+# Drop once upstream requires golang.org/x/text >= v0.39.0.
+-replace golang.org/x/text=golang.org/x/text@v0.39.0


### PR DESCRIPTION
## What this does

Updates `go-mod-overrides` to resolve vulnerabilities reported by Trivy against `rancher/hardened-flannel:v0.28.7-build20260709` (in the `opt/bin/flanneld` binary):

| Library | Vulnerability | Installed | Fixed |
| --- | --- | --- | --- |
| `golang.org/x/net` | CVE-2026-46600 — parsing an invalid SVCB or HTTPS RR can panic in `golang.org/x/net/dns/dnsmessage` | v0.55.0 | v0.56.0 |
| `golang.org/x/text` | CVE-2026-56852 — infinite loop on invalid input in `golang.org/x/text` | v0.37.0 | v0.39.0 |

### Changes
- Bump the existing `golang.org/x/net` override from `v0.55.0` to `v0.56.0` (and note CVE-2026-46600 in the comment).
- Add a new `golang.org/x/text` override at `v0.39.0`.

These overrides can be dropped once upstream requires `golang.org/x/net >= v0.56.0` and `golang.org/x/text >= v0.39.0`.

> Note: the scan also flags `golang.org/x/crypto` GO-2026-5932 (unmaintained `openpgp` package). It has no fixed version available, so it cannot be resolved via a module override and is not addressed here.

Follows the same approach as rancher/image-build-dns-nodecache#188.