### PR TITLE
Remove redundant google.golang.org/grpc go-mod-override

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -5,7 +5,3 @@
 # golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
 # Drop once upstream requires golang.org/x/text >= v0.39.0.
 -replace golang.org/x/text=golang.org/x/text@v0.39.0
-
-# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
-# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
--replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1


### PR DESCRIPTION
## Summary

Removes the `google.golang.org/grpc` override from `go-mod-overrides`. Upstream flannel-io/flannel `go.mod` now already requires `google.golang.org/grpc v1.82.1` (see https://github.com/flannel-io/flannel/blob/master/go.mod), so pinning it here is no longer necessary.

## Overrides kept

The remaining overrides stay in place because upstream still requires versions below their CVE-patched releases:

- `golang.org/x/net` → `v0.56.0`: upstream still requires `v0.55.0`.
- `golang.org/x/text` → `v0.39.0`: upstream still requires `v0.37.0`.

These will be dropped once upstream catches up.